### PR TITLE
Change communication pattern in distributed embedding layer to avoid barriers

### DIFF
--- a/src/layers/misc/dist_embedding.cpp
+++ b/src/layers/misc/dist_embedding.cpp
@@ -132,7 +132,6 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
 #else // LBANN_HAS_SHMEM
 
   // Data matrices
-  using LocalMat = El::Matrix<TensorDataType, Device>;
   const auto& embeddings = this->get_data_type_weights(0).get_values();
   const auto& input = this->get_prev_activations();
   const auto& local_input = dynamic_cast<const LocalMat&>(input.LockedMatrix());
@@ -234,9 +233,6 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
 #else // LBANN_HAS_SHMEM
 
   // Data matrices
-  using LocalMat = El::Matrix<TensorDataType, Device>;
-  auto& embeddings = this->get_data_type_weights(0).get_values();
-  auto& local_embeddings = dynamic_cast<LocalMat&>(embeddings.Matrix());
   const auto& input = this->get_prev_activations();
   const auto& local_output_grad = dynamic_cast<const LocalMat&>(this->get_local_prev_error_signals());
 
@@ -244,9 +240,6 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
   const size_t input_size = this->get_input_size();
   const size_t mini_batch_size = input.Width();
   const size_t local_mini_batch_size = local_output_grad.Width();
-
-  // SHMEM processing element
-  const size_t rank = this->get_comm()->get_rank_in_trainer();
 
   // Initialize SHMEM buffer for gradient w.r.t. embeddings
   LocalMat workspace(
@@ -274,23 +267,60 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
   }
   shmem_barrier_all(); /// @todo Smarter synchronization
 
-  // Configure local embeddings for sparse SGD
-  // Note: If we are not doing sparse SGD, then we initialize
-  // embeddings_v as a tensor of zeros. Applying sparse SGD to this
-  // tensor results in the full gradient tensor, which can then be
-  // sent to a dense optimizer.
-  LocalMat local_embeddings_v;
-  std::unique_ptr<El::AbstractDistMatrix<TensorDataType>> embeddings_grad;
-  if (m_sparse_sgd) {
-    El::View(local_embeddings_v, local_embeddings);
-  }
-  else {
-    embeddings_grad.reset(
+  // Use dense optimizer if needed
+  if (!m_sparse_sgd) {
+
+    // Create buffer for dense gradients
+    auto& embeddings = this->get_data_type_weights(0).get_values();
+    std::unique_ptr<El::AbstractDistMatrix<TensorDataType>> embeddings_grad(
       embeddings.Construct(embeddings.Grid(), embeddings.Root()));
     embeddings_grad->AlignWith(embeddings);
     El::Zeros(*embeddings_grad, embeddings.Height(), embeddings.Width());
-    El::View(local_embeddings_v, embeddings_grad->Matrix());
+    auto& local_embeddings_grad = dynamic_cast<LocalMat&>(embeddings_grad->Matrix());
+
+    // Apply SGD step to convert sparse gradients to dense gradients
+    apply_sparse_sgd_step(
+      input_size * mini_batch_size,
+      local_embeddings_grad);
+
+    // Send dense gradients to dense optimizer
+    auto&& opt = this->get_data_type_weights(0).get_optimizer();
+    if (opt != nullptr) {
+      opt->add_to_gradient(*embeddings_grad);
+    }
+
   }
+
+#endif // LBANN_HAS_SHMEM
+}
+
+// =============================================
+// Sparse SGD
+// =============================================
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void dist_embedding_layer<TensorDataType,Layout,Device>::apply_sparse_sgd_step(
+  size_t num_gradients,
+  LocalMat& local_embeddings) {
+#ifndef LBANN_HAS_SHMEM
+  LBANN_ERROR(
+    "dist_embedding_layer with ",
+    "(TensorDataType=",TypeName<TensorDataType>(),", ",
+    "Layout=",to_string(Layout),", ",
+    "Device=",to_string(Device),") ",
+    "requires SHMEM, but LBANN has not been built with SHMEM");
+  return;
+#else // LBANN_HAS_SHMEM
+
+  // SHMEM processing element
+  const size_t rank = this->get_comm()->get_rank_in_trainer();
+
+  // Initialize SHMEM buffer for gradient w.r.t. embeddings
+  LocalMat local_embeddings_grad(
+    m_embedding_dim,
+    num_gradients,
+    m_workspace_buffer,
+    m_embedding_dim);
 
   // Sparse SGD on local embeddings
   const size_t num_omp_threads = omp_get_num_threads();
@@ -300,26 +330,20 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
   for (size_t thread = 0; thread < num_omp_threads; ++thread) {
     const size_t index_start = thread * embeddings_per_thread;
     const size_t index_end = (thread+1) * embeddings_per_thread;
-    for (size_t i=0; i<input_size*mini_batch_size; ++i) {
-      auto& req = m_requests_buffer[i];
+    for (size_t i=0; i<num_gradients; ++i) {
+      const auto& req = m_requests_buffer[i];
       if (req.is_active
           && req.source_rank == rank
           && index_start <= req.source_index
           && req.source_index < index_end) {
-        const auto* dw = workspace.LockedBuffer(0, req.target_index);
-        auto* w = local_embeddings_v.Buffer(0, req.source_index);
+        const auto* dw = local_embeddings_grad.LockedBuffer(0, req.target_index);
+        auto* w = local_embeddings.Buffer(0, req.source_index);
         EL_SIMD
         for (size_t k = 0; k < m_embedding_dim; ++k) {
           w[k] -= m_learning_rate * dw[k];
         }
       }
     }
-  }
-
-  // Send gradients to dense optimizer if needed
-  auto&& opt = this->get_data_type_weights(0).get_optimizer();
-  if (!m_sparse_sgd && opt != nullptr) {
-    opt->add_to_gradient(*embeddings_grad);
   }
 
 #endif // LBANN_HAS_SHMEM

--- a/src/layers/misc/dist_embedding.cpp
+++ b/src/layers/misc/dist_embedding.cpp
@@ -42,15 +42,76 @@ constexpr long flag_val = 1;
 } // namespace <anon>
 
 // =============================================
-// Life cycle functions
+// Life cycle and setup
 // =============================================
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 dist_embedding_layer<TensorDataType,Layout,Device>::~dist_embedding_layer()
 {
 #ifdef LBANN_HAS_SHMEM
+  shmem_free(m_embeddings_buffer);
   shmem_free(m_workspace_buffer);
   shmem_free(m_requests_buffer);
+#endif // LBANN_HAS_SHMEM
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void dist_embedding_layer<TensorDataType,Layout,Device>::attach_embeddings_to_shmem_buffer() {
+#ifndef LBANN_HAS_SHMEM
+  LBANN_ERROR(
+    "dist_embedding_layer with ",
+    "(TensorDataType=",TypeName<TensorDataType>(),", ",
+    "Layout=",to_string(Layout),", ",
+    "Device=",to_string(Device),") ",
+    "requires SHMEM, but LBANN has not been built with SHMEM");
+  return;
+#else
+  if (m_embeddings_buffer != nullptr || m_embeddings_buffer_size != 0) {
+    LBANN_ERROR("attempted to attach embedding matrix ",
+                "to OpenSHMEM buffer multiple times");
+  }
+
+  // Embedding weights matrix
+  auto& embeddings = this->get_data_type_weights(0).get_values();
+  const auto dist = embeddings.DistData();
+  if (dist.device != El::Device::CPU) {
+    LBANN_ERROR("attempted to attach non-CPU matrix to OpenSHMEM buffer");
+  }
+  if (shmem_addr_accessible(embeddings.LockedBuffer(), shmem_my_pe())) {
+    return;
+  }
+
+  // Calculate size of SHMEM buffer
+  const auto col_comm_size = El::mpi::Size(embeddings.ColComm());
+  const auto row_comm_size = El::mpi::Size(embeddings.RowComm());
+  const auto height = embeddings.Height();
+  const auto width = embeddings.Width();
+  const auto local_height = (height + col_comm_size - 1) / col_comm_size;
+  const auto local_width = (width + row_comm_size - 1) / row_comm_size;
+  m_embeddings_buffer_size = local_height * local_width * sizeof(TensorDataType);
+  if (m_embeddings_buffer_size == 0) {
+    return;
+  }
+
+  // Allocate SHMEM buffer
+  m_embeddings_buffer = reinterpret_cast<TensorDataType*>(
+    shmem_malloc(m_embeddings_buffer_size));
+  if (m_embeddings_buffer == nullptr) {
+    LBANN_ERROR("failed to allocate OpenSHMEM buffer");
+  }
+
+  // Attach matrix to SHMEM buffer
+  std::unique_ptr<El::AbstractDistMatrix<TensorDataType>> orig_mat(
+    embeddings.Construct(embeddings.Grid(), embeddings.Root()));
+  *orig_mat = std::move(embeddings);
+  embeddings.Empty();
+  embeddings.AlignWith(dist);
+  dynamic_cast<El::ElementalMatrix<TensorDataType>&>(embeddings).Attach(
+    height, width,
+    *dist.grid, dist.colAlign, dist.rowAlign,
+    m_embeddings_buffer, local_height, dist.root);
+  El::Copy(*orig_mat, embeddings);
+
 #endif // LBANN_HAS_SHMEM
 }
 
@@ -102,7 +163,8 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
     m_workspace_buffer,
     m_embedding_dim);
 
-  // Initialize SHMEM buffer for shmem_put requests
+  // Initialize SHMEM buffer for vector requests
+  /// @todo Smarter synchronization
   if (m_requests_buffer_size < input_size * mini_batch_size) {
     m_requests_buffer_size = input_size * mini_batch_size;
     m_requests_buffer = reinterpret_cast<RequestType*>(
@@ -115,9 +177,9 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
     m_requests_buffer,
     m_requests_buffer+m_requests_buffer_size,
     RequestType());
-
-  // Request embedding vectors from owner processes
   shmem_barrier_all();
+
+  // Get embedding vectors from owner processes
   for (size_t j=0; j<local_mini_batch_size; ++j) {
     for (size_t i=0; i<input_size; ++i) {
       const auto& global_index = static_cast<size_t>(std::floor(local_input(i,j)));
@@ -131,42 +193,13 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
       req.target_index = i + global_j*input_size;
       req.is_active = true;
 
-      // Send request to owner process
-      shmem_putmem_nbi(
-        &req,
-        &req,
-        sizeof(RequestType),
-        req.source_rank);
-
-    }
-  }
-  shmem_barrier_all();
-
-  // Send my embedding vectors to requesting processes
-  for (size_t i=0; i<input_size*mini_batch_size; ++i) {
-    const auto& req = m_requests_buffer[i];
-    if (req.is_active && req.source_rank == rank) {
-      shmem_putmem_nbi(
+      // Get embedding vector from owner process
+      shmem_getmem_nbi(
         workspace.Buffer(0, req.target_index),
         embeddings.LockedBuffer(0, req.source_index),
         m_embedding_dim*sizeof(TensorDataType),
-        req.target_rank);
-    }
-  }
+        req.source_rank);
 
-  // Notify requesting processes that they have recieved my embedding vectors
-  // Note: The shmem_quiet afterwards is not needed, but it improves
-  // performance. I speculate that it yields the CPU, providing more
-  // resources for the asynchronous communication.
-  shmem_fence();
-  for (size_t i=0; i<input_size*mini_batch_size; ++i) {
-    auto& req = m_requests_buffer[i];
-    if (req.is_active && req.source_rank == rank) {
-      shmem_long_put_nbi(
-        &req.is_completed,
-        &flag_val,
-        1,
-        req.target_rank);
     }
   }
   shmem_quiet();
@@ -175,9 +208,6 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
   for (size_t j=0; j<local_mini_batch_size; ++j) {
     for (size_t i=0; i<input_size; ++i) {
       const auto& global_j = input.GlobalCol(j);
-      auto& req = m_requests_buffer[i + global_j*input_size];
-      shmem_wait(&req.is_completed, 0);
-      req.is_completed = 0;
       const auto* x = workspace.LockedBuffer(0, i + global_j*input_size);
       auto* y = local_output.Buffer(i*m_embedding_dim, j);
       std::copy(x, x+m_embedding_dim, y);
@@ -229,32 +259,20 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
   for (size_t j=0; j<local_mini_batch_size; ++j) {
     for (size_t i=0; i<input_size; ++i) {
       const auto& global_j = input.GlobalCol(j);
-      const auto& req = m_requests_buffer[i + global_j*input_size];
+      auto& req = m_requests_buffer[i + global_j*input_size];
       shmem_putmem_nbi(
         workspace.Buffer(0, i+global_j*input_size),
         local_output_grad.LockedBuffer(i*m_embedding_dim, j),
         m_embedding_dim*sizeof(TensorDataType),
         req.source_rank);
-    }
-  }
-
-  // Notify owner processes that they have recieved gradients
-  // Note: The shmem_quiet afterwards is not needed, but it improves
-  // performance. I speculate that it yields the CPU, providing more
-  // resources for the asynchronous communication.
-  shmem_fence();
-  for (size_t j=0; j<local_mini_batch_size; ++j) {
-    for (size_t i=0; i<input_size; ++i) {
-      const auto& global_j = input.GlobalCol(j);
-      auto& req = m_requests_buffer[i + global_j*input_size];
-      shmem_long_put_nbi(
-        &req.is_completed,
-        &flag_val,
-        1,
+      shmem_putmem_nbi(
+        &req,
+        &req,
+        sizeof(RequestType),
         req.source_rank);
     }
   }
-  shmem_quiet();
+  shmem_barrier_all(); /// @todo Smarter synchronization
 
   // Configure local embeddings for sparse SGD
   // Note: If we are not doing sparse SGD, then we initialize
@@ -288,19 +306,12 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
           && req.source_rank == rank
           && index_start <= req.source_index
           && req.source_index < index_end) {
-
-        // Wait until gradient has been recieved
-        shmem_wait(&req.is_completed, 0);
-        req.is_completed = 0;
-
-        // Update embedding with gradient
         const auto* dw = workspace.LockedBuffer(0, req.target_index);
         auto* w = local_embeddings_v.Buffer(0, req.source_index);
         EL_SIMD
         for (size_t k = 0; k < m_embedding_dim; ++k) {
           w[k] -= m_learning_rate * dw[k];
         }
-
       }
     }
   }

--- a/src/layers/misc/dist_embedding.cu
+++ b/src/layers/misc/dist_embedding.cu
@@ -129,7 +129,7 @@ inline void launch_nvshmem_collective_kernel(
 } // namespace <anon>
 
 // =============================================
-// Life cycle functions
+// Life cycle and setup
 // =============================================
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
@@ -142,6 +142,22 @@ dist_embedding_layer<TensorDataType,Layout,Device>::~dist_embedding_layer()
   if (m_requests_buffer != nullptr) {
     nvshmem_free(m_requests_buffer);
   }
+#endif // LBANN_HAS_NVSHMEM
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void dist_embedding_layer<TensorDataType,Layout,Device>::attach_embeddings_to_shmem_buffer() {
+#ifndef LBANN_HAS_NVSHMEM
+    LBANN_ERROR(
+    "dist_embedding_layer with ",
+    "(TensorDataType=",TypeName<TensorDataType>(),", ",
+    "Layout=",to_string(Layout),", ",
+    "Device=",to_string(Device),") ",
+    "requires NVSHMEM, but LBANN has not been built with NVSHMEM");
+  return;
+#else
+  /// @todo Implement
+  LBANN_ERROR("not yet implemented");
 #endif // LBANN_HAS_NVSHMEM
 }
 

--- a/src/layers/misc/dist_embedding.cu
+++ b/src/layers/misc/dist_embedding.cu
@@ -74,15 +74,15 @@ size_t distmat_local_index(size_t global_index, size_t rank, size_t align, size_
   }
 }
 
-template <typename Kernel, typename... ArgTs>
+template <typename Kernel, typename... Args>
 inline void launch_cuda_kernel(
   const Kernel& kernel,
   dim3 grid_dims,
   dim3 block_dims,
   size_t shared_mem,
   cudaStream_t stream,
-  ArgTs... args) {
-  void *arg_list[] = {
+  Args... args) {
+  void* arg_list[] = {
     const_cast<void*>(reinterpret_cast<const void*>(&args))...
   };
   CHECK_CUDA(
@@ -96,19 +96,19 @@ inline void launch_cuda_kernel(
 }
 
 #ifdef LBANN_HAS_NVSHMEM
-template <typename Kernel, typename... ArgTs>
+template <typename Kernel, typename... Args>
 inline void launch_nvshmem_collective_kernel(
   const Kernel& kernel,
   dim3 grid_dims,
   dim3 block_dims,
   size_t shared_mem,
   cudaStream_t stream,
-  ArgTs... args) {
+  Args... args) {
   if (grid_dims.x == 0) {
     grid_dims.y = 0;
     grid_dims.z = 0;
   }
-  void *arg_list[] = {
+  void* arg_list[] = {
     const_cast<void*>(reinterpret_cast<const void*>(&args))...
   };
   auto status = nvshmemx_collective_launch(
@@ -136,6 +136,9 @@ template <typename TensorDataType, data_layout Layout, El::Device Device>
 dist_embedding_layer<TensorDataType,Layout,Device>::~dist_embedding_layer()
 {
 #ifdef LBANN_HAS_NVSHMEM
+  if (m_embeddings_buffer != nullptr) {
+    nvshmem_free(m_embeddings_buffer);
+  }
   if (m_workspace_buffer != nullptr) {
     nvshmem_free(m_workspace_buffer);
   }
@@ -156,8 +159,50 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::attach_embeddings_to_sh
     "requires NVSHMEM, but LBANN has not been built with NVSHMEM");
   return;
 #else
-  /// @todo Implement
-  LBANN_ERROR("not yet implemented");
+  if (m_embeddings_buffer != nullptr || m_embeddings_buffer_size != 0) {
+    LBANN_ERROR("attempted to attach embedding matrix ",
+                "to NVSHMEM buffer multiple times");
+  }
+
+  // Embedding weights matrix
+  auto& embeddings = this->get_data_type_weights(0).get_values();
+  const auto dist = embeddings.DistData();
+  if (dist.device != El::Device::GPU) {
+    LBANN_ERROR("attempted to attach non-GPU matrix to NVSHMEM buffer");
+  }
+#if 0 // nvshmem_addr_accessible is not supported as of NVSHMEM 1.4
+  if (nvshmem_addr_accessible(embeddings.LockedBuffer(), nvshmem_my_pe())) {
+    return;
+  }
+#endif
+
+  // Calculate size of SHMEM buffer
+  const auto col_comm_size = El::mpi::Size(embeddings.ColComm());
+  const auto row_comm_size = El::mpi::Size(embeddings.RowComm());
+  const auto height = embeddings.Height();
+  const auto width = embeddings.Width();
+  const auto local_height = (height + col_comm_size - 1) / col_comm_size;
+  const auto local_width = (width + row_comm_size - 1) / row_comm_size;
+  m_embeddings_buffer_size = local_height * local_width * sizeof(TensorDataType);
+  if (m_embeddings_buffer_size == 0) {
+    return;
+  }
+
+  // Allocate NVSHMEM buffer
+  m_embeddings_buffer = nvshmem::malloc<TensorDataType>(m_embeddings_buffer_size);
+
+  // Attach matrix to NVSHMEM buffer
+  std::unique_ptr<El::AbstractDistMatrix<TensorDataType>> orig_mat(
+    embeddings.Construct(embeddings.Grid(), embeddings.Root()));
+  *orig_mat = std::move(embeddings);
+  embeddings.Empty();
+  embeddings.AlignWith(dist);
+  dynamic_cast<El::ElementalMatrix<TensorDataType>&>(embeddings).Attach(
+    height, width,
+    *dist.grid, dist.colAlign, dist.rowAlign,
+    m_embeddings_buffer, local_height, dist.root);
+  El::Copy(*orig_mat, embeddings);
+
 #endif // LBANN_HAS_NVSHMEM
 }
 
@@ -175,12 +220,17 @@ namespace {
  *  Grid dimensions: input_dims[1] x input_dims[0] x 1
  */
 template <typename TensorDataType>
-__global__ void send_requests_kernel(
+__global__ void request_embeddings_kernel(
+  size_t embedding_dim,
   Size2 input_dims,
   const TensorDataType* __restrict__ input,
   Size2 input_strides,
+  const TensorDataType* __restrict__ embeddings,
+  Size2 embeddings_strides,
   RequestType* __restrict__ requests,
   Size2 requests_strides,
+  TensorDataType* __restrict__ workspace,
+  Size2 workspace_strides,
   size_t rank,
   size_t input_rowshift,
   size_t input_rowstride,
@@ -192,7 +242,6 @@ __global__ void send_requests_kernel(
   const size_t bidy = blockIdx.y;
   const size_t nblocksx = gridDim.x;
   const size_t nblocksy = gridDim.y;
-  const bool am_warp_master = threadIdx.x == 0;
 
   const size_t i_per_block = (input_dims[1] + nblocksx - 1) / nblocksx;
   const size_t i_start = bidx * i_per_block;
@@ -202,26 +251,27 @@ __global__ void send_requests_kernel(
       const auto& global_j = distmat_global_index(j, input_rowshift, input_rowstride);
 
       // Get embedding vector index
-      const auto& global_index_float
-        = input[i*input_strides[1] + j*input_strides[0]];
+      const auto& global_index_float = input[i*input_strides[1] + j*input_strides[0]];
       const auto& global_index = static_cast<size_t>(cuda::floor(global_index_float));
 
       // Figure out which process owns embedding vector
-      auto& req = requests[i*requests_strides[1] + global_j*requests_strides[0]];
-      if (am_warp_master) {
+      __shared__ unsigned char req_buffer[sizeof(RequestType)];
+      auto& req = *reinterpret_cast<RequestType*>(req_buffer);
+      if (threadIdx.x == 0) {
         req.source_rank = distmat_index_owner(global_index, embeddings_rowalign, embeddings_rowstride);
         req.source_index = distmat_local_index(global_index, req.source_rank, embeddings_rowalign, embeddings_rowstride);
         req.target_rank = rank;
         req.target_index = i + global_j*input_dims[1];
         req.is_active = true;
+        requests[i*requests_strides[1] + global_j*requests_strides[0]] = req;
       }
       __syncwarp();
 
-      // Send request to owner process
-      nvshmemx_putmem_nbi_warp(
-        &req,
-        &req,
-        sizeof(RequestType),
+      // Get embedding vector from owner process
+      nvshmemx_getmem_nbi_warp(
+        &workspace[req.target_index * workspace_strides[0]],
+        &embeddings[req.source_index * embeddings_strides[0]],
+        embedding_dim*sizeof(TensorDataType),
         req.source_rank);
 
     }
@@ -231,89 +281,17 @@ __global__ void send_requests_kernel(
 #endif // LBANN_HAS_NVSHMEM
 
 #ifdef LBANN_HAS_NVSHMEM
-/** Send my embedding vectors to requesting processes.
+/** Copy embedding vectors to output tensor.
  *
  *  Block dimensions: 32 x 1 x 1
  *
- *  Grid dimensions: num_requests x 1 x 1
+ *  Grid dimensions: input_dims[1] x input_dims[0] x 1
  */
 template <typename TensorDataType>
-__global__ void send_embeddings_kernel(
-  size_t embedding_dim,
-  size_t num_requests,
-  RequestType* __restrict__ requests,
-  const TensorDataType* __restrict__ embeddings,
-  Size2 embeddings_strides,
-  TensorDataType* __restrict__ workspace,
-  Size2 workspace_strides,
-  size_t rank) {
-
-  // Indices
-  const size_t bid = blockIdx.x;
-  const size_t nblocks = gridDim.x;
-  const bool am_warp_master = threadIdx.x == 0;
-
-  // Assign requests to CUDA blocks
-  const size_t requests_per_block = (num_requests + nblocks - 1) / nblocks;
-  const size_t i_start = bid * requests_per_block;
-  const size_t i_end = cuda::min((bid+1) * requests_per_block, num_requests);
-
-  // Send my embedding vectors to requesting processes
-  for (size_t i = i_start; i < i_end; ++i) {
-    const auto& req = requests[i];
-    if (req.is_active && req.source_rank == rank) {
-      auto* workspace_ptr = &workspace[req.target_index * workspace_strides[0]];
-      memcpy_warp(
-        workspace_ptr,
-        &embeddings[req.source_index * embeddings_strides[0]],
-        embedding_dim);
-      if (req.target_rank != rank) {
-        nvshmemx_putmem_nbi_warp(
-          workspace_ptr,
-          workspace_ptr,
-          embedding_dim*sizeof(TensorDataType),
-          req.target_rank);
-      }
-    }
-  }
-
-  // Notify requesting processes that they have recieved my embedding vectors
-  __syncwarp();
-  if (am_warp_master) {
-    nvshmem_fence();
-  }
-  for (size_t i = i_start; i < i_end; ++i) {
-    auto& req = requests[i];
-    if (req.is_active && req.source_rank == rank) {
-      if (am_warp_master) {
-        req.is_completed = 1;
-      }
-      __syncwarp();
-      if (req.target_rank != rank) {
-        nvshmemx_long_put_nbi_warp(
-          &req.is_completed,
-          &req.is_completed,
-          1,
-          req.target_rank);
-      }
-    }
-  }
-
-}
-#endif // LBANN_HAS_NVSHMEM
-
-#ifdef LBANN_HAS_NVSHMEM
-/** Wait for embedding vectors from owner processes.
- *
- *  Block dimensions: 32 x 1 x 1
- *
- *  Grid dimensions: Max allowed by NVSHMEM
- */
-template <typename TensorDataType>
-__global__ void wait_for_embeddings_kernel(
+__global__ void copy_embeddings_kernel(
   size_t embedding_dim,
   Size2 input_dims,
-  RequestType* __restrict__ requests,
+  const RequestType* __restrict__ requests,
   Size2 requests_strides,
   const TensorDataType* __restrict__ workspace,
   Size2 workspace_strides,
@@ -327,31 +305,18 @@ __global__ void wait_for_embeddings_kernel(
   const size_t bidy = blockIdx.y;
   const size_t nblocksx = gridDim.x;
   const size_t nblocksy = gridDim.y;
-  const bool am_warp_master = threadIdx.x == 0;
 
-  // Assign requests to CUDA blocks
   const size_t i_per_block = (input_dims[1] + nblocksx - 1) / nblocksx;
   const size_t i_start = bidx * i_per_block;
   const size_t i_end = cuda::min((bidx+1) * i_per_block, input_dims[1]);
-
   for (size_t j = bidy; j < input_dims[0]; j += nblocksy) {
     for (size_t i = i_start; i < i_end; ++i) {
       const auto& global_j = distmat_global_index(j, input_rowshift, input_rowstride);
-
-      // Wait for embedding vector to arrive
-      auto& req = requests[i*requests_strides[1] + global_j*requests_strides[0]];
-      if (am_warp_master) {
-        nvshmem_wait(&req.is_completed, 0);
-        req.is_completed = 0;
-      }
-      __syncwarp();
-
-      // Copy embedding vector to output tensor
+      const auto& req = requests[i*requests_strides[1] + global_j*requests_strides[0]];
       memcpy_warp(
         &output[i*embedding_dim + j*output_strides[0]],
-        &workspace[req.target_index*workspace_strides[0]],
+        &workspace[req.target_index * workspace_strides[0]],
         embedding_dim);
-
     }
   }
 
@@ -404,7 +369,8 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
     m_workspace_buffer,
     m_embedding_dim);
 
-  // Initialize NVSHMEM buffer for shmem_put requests
+  // Initialize NVSHMEM buffer for vector requests
+  /// @todo Smarter synchronization
   if (m_requests_buffer_size < input_size * mini_batch_size) {
     m_requests_buffer_size = input_size * mini_batch_size;
     m_requests_buffer = nvshmem::realloc(m_requests_buffer,
@@ -416,9 +382,9 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
       0,
       m_requests_buffer_size*sizeof(RequestType),
       stream));
-
-  // Request embedding vectors from owner processes
   nvshmemx_barrier_all_on_stream(stream);
+
+  // Request embedding vectors from owning processes
   if (!local_input.IsEmpty()) {
     constexpr size_t block_size = 32;
     dim3 block_dims, grid_dims;
@@ -426,54 +392,40 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::fp_compute() {
     grid_dims.x = input_size;
     grid_dims.y = local_mini_batch_size;
     launch_cuda_kernel(
-      send_requests_kernel<TensorDataType>,
+      request_embeddings_kernel<TensorDataType>,
       grid_dims,
       block_dims,
       0,
       stream,
+      m_embedding_dim,
       Size2{local_mini_batch_size, input_size},
-      size_t(local_input.LockedBuffer()),
+      local_input.LockedBuffer(),
       Size2{size_t(local_input.LDim()), 1},
+      embeddings.LockedBuffer(),
+      Size2{size_t(embeddings.LDim()), 1},
       m_requests_buffer,
       Size2{input_size, 1},
+      workspace.Buffer(),
+      Size2{size_t(workspace.LDim()), 1},
       size_t(rank),
       size_t(input.RowShift()),
       size_t(input.RowStride()),
       size_t(embeddings.RowAlign()),
       size_t(embeddings.RowStride()));
   }
-  nvshmemx_barrier_all_on_stream(stream);
+  nvshmemx_quiet_on_stream(stream);
 
-  // Send my embedding vectors to requesting processes
-  {
+  // Copy embedding vectors to output tensor
+  if (!local_output.IsEmpty()) {
     constexpr size_t block_size = 32;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
-    grid_dims.x = input_size * mini_batch_size;
+    grid_dims.x = input_size;
+    grid_dims.y = local_mini_batch_size;
     launch_cuda_kernel(
-      send_embeddings_kernel<TensorDataType>,
+      copy_embeddings_kernel<TensorDataType>,
       grid_dims,
       block_dims,
-      0,
-      stream,
-      m_embedding_dim,
-      input_size * mini_batch_size,
-      m_requests_buffer,
-      embeddings.LockedBuffer(),
-      Size2{size_t(embeddings.LDim()), 1},
-      workspace.Buffer(),
-      Size2{size_t(workspace.LDim()), 1},
-      rank);
-  }
-  nvshmemx_quiet_on_stream(stream);
-
-  // Copy embedding vectors from workspace to output tensor
-  {
-    constexpr size_t block_size = 32;
-    launch_nvshmem_collective_kernel(
-      wait_for_embeddings_kernel<TensorDataType>,
-      0,
-      block_size,
       0,
       stream,
       m_embedding_dim,
@@ -508,10 +460,10 @@ template <typename TensorDataType>
 __global__ void send_gradients_kernel(
   size_t embedding_dim,
   Size2 input_dims,
-  RequestType* __restrict__ requests,
-  Size2 requests_strides,
   const TensorDataType* __restrict__ output_grad,
   Size2 output_grad_strides,
+  RequestType* __restrict__ requests,
+  Size2 requests_strides,
   TensorDataType* __restrict__ workspace,
   Size2 workspace_strides,
   size_t input_rowshift,
@@ -522,7 +474,6 @@ __global__ void send_gradients_kernel(
   const size_t bidy = blockIdx.y;
   const size_t nblocksx = gridDim.x;
   const size_t nblocksy = gridDim.y;
-  const bool am_warp_master = threadIdx.x == 0;
 
   // Assign requests to CUDA blocks
   const size_t i_per_block = (input_dims[1] + nblocksx - 1) / nblocksx;
@@ -541,32 +492,14 @@ __global__ void send_gradients_kernel(
         embedding_dim);
       if (req.source_rank != req.target_rank) {
         nvshmemx_putmem_nbi_warp(
+          &req,
+          &req,
+          sizeof(RequestType),
+          req.source_rank);
+        nvshmemx_putmem_nbi_warp(
           workspace_ptr,
           workspace_ptr,
           embedding_dim*sizeof(TensorDataType),
-          req.source_rank);
-      }
-    }
-  }
-
-  // Notify owner processes that they have recieved gradients
-  __syncwarp();
-  if (am_warp_master) {
-    nvshmem_fence();
-  }
-  for (size_t j = bidy; j < input_dims[0]; j += nblocksy) {
-    for (size_t i = i_start; i < i_end; ++i) {
-      const auto& global_j = distmat_global_index(j, input_rowshift, input_rowstride);
-      auto& req = requests[i*requests_strides[1] + global_j*requests_strides[0]];
-      if (am_warp_master) {
-        req.is_completed = 1;
-      }
-      __syncwarp();
-      if (req.source_rank != req.target_rank) {
-        nvshmemx_long_put_nbi_warp(
-          &req.is_completed,
-          &req.is_completed,
-          1,
           req.source_rank);
       }
     }
@@ -587,7 +520,7 @@ __global__ void sgd_kernel(
   TensorDataType learning_rate,
   size_t embedding_dim,
   size_t num_requests,
-  RequestType* __restrict__ requests,
+  const RequestType* __restrict__ requests,
   const TensorDataType* __restrict__ workspace,
   Size2 workspace_strides,
   TensorDataType* __restrict__ embeddings,
@@ -599,7 +532,6 @@ __global__ void sgd_kernel(
   const size_t bid = blockIdx.x;
   const size_t nblocks = gridDim.x;
   constexpr size_t warp_size = 32;
-  const bool am_warp_master = threadIdx.x == 0;
 
   // Assign requests to CUDA blocks
   const size_t requests_per_block = (num_requests + nblocks - 1) / nblocks;
@@ -607,15 +539,8 @@ __global__ void sgd_kernel(
   const size_t i_end = cuda::min((bid+1) * requests_per_block, num_requests);
 
   for (size_t i = i_start; i < i_end; ++i) {
-    auto& req = requests[i];
+    const auto& req = requests[i];
     if (req.is_active && req.source_rank == rank) {
-
-      // Wait for gradient to arrive
-      if (am_warp_master) {
-        nvshmem_wait(&req.is_completed, 0);
-        req.is_completed = 0;
-      }
-      __syncwarp();
 
       // Update embedding vector with gradient
       const auto* __restrict__ dw = &workspace[req.target_index * workspace_strides[0]];
@@ -684,16 +609,16 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
       stream,
       m_embedding_dim,
       Size2{local_mini_batch_size, input_size},
-      m_requests_buffer,
-      Size2{input_size, 1},
       local_output_grad.LockedBuffer(),
       Size2{size_t(local_output_grad.LDim()), 1},
+      m_requests_buffer,
+      Size2{input_size, 1},
       workspace.Buffer(),
       Size2{size_t(workspace.LDim()), 1},
       size_t(input.RowShift()),
       size_t(input.RowStride()));
   }
-  nvshmemx_quiet_on_stream(stream);
+  nvshmemx_barrier_all_on_stream(stream);
 
   // Configure local embeddings for sparse SGD
   // Note: If we are not doing sparse SGD, then we initialize
@@ -716,9 +641,10 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::bp_compute() {
   // Sparse SGD on local embeddings
   {
     constexpr size_t block_size = 32;
-    launch_nvshmem_collective_kernel(
+    const size_t grid_size = input_size * mini_batch_size;
+    launch_cuda_kernel(
       sgd_kernel<TensorDataType>,
-      0,
+      grid_size,
       block_size,
       0,
       stream,


### PR DESCRIPTION
The distributed embedding layer "gets" embeddings in forward prop and "puts" embedding gradients in backprop. Synchronization is performed with quiets and non-blocking barriers (currently implemented as non-blocking allreduces on a single `float`).