### PR TITLE
Added a cache for GRU cuda graphs.  Both forward and backward prop

### DIFF
--- a/include/lbann/layers/learning/gru.hpp
+++ b/include/lbann/layers/learning/gru.hpp
@@ -41,6 +41,20 @@
 
 namespace lbann {
 
+#ifdef LBANN_GRU_LAYER_GPU_SUPPORTED
+struct cuda_graph_cache_t {
+  /** @brief CUDA graph for cuDNN forward prop function */
+  cuda::ExecutableGraph m_graph;
+  /** @brief Hash for @c m_cuda_graph_forward_prop
+   *
+   *  Hash is generated with input arguments to cuDNN function (mostly
+   *  workspace buffer pointers).
+   */
+  size_t m_hash{0};
+};
+typedef std::unordered_map<size_t, cuda_graph_cache_t> cuda_graph_cache_map_t;
+#endif // LBANN_GRU_LAYER_GPU_SUPPORTED
+
 /** @brief Stacked gated recurrent unit
  *
  *  Expects two inputs: a 2D input sequence (
@@ -128,23 +142,10 @@ private:
   ByteBuffer m_cudnn_reserve_space;
   hydrogen::simple_buffer<int32_t, El::Device::GPU> m_gpu_sequence_lengths;
 
-  /** @brief CUDA graph for cuDNN forward prop function */
-  cuda::ExecutableGraph m_cuda_graph_forward_prop;
-  /** @brief Hash for @c m_cuda_graph_forward_prop
-   *
-   *  Hash is generated with input arguments to cuDNN function (mostly
-   *  workspace buffer pointers).
-   */
-  size_t m_cuda_graph_forward_prop_hash{0};
-  /** @brief CUDA graph for cuDNN backprop functions */
-  cuda::ExecutableGraph m_cuda_graph_backward_prop;
-  /** @brief Hash for @c m_cuda_graph_backward_prop
-   *
-   *  Hash is generated with input arguments to cuDNN functions (mostly
-   *  workspace buffer pointers).
-   */
-  size_t m_cuda_graph_backward_prop_hash{0};
-
+  /** @brief Cache of CUDA graphs for cuDNN forward prop function */
+  cuda_graph_cache_map_t m_cuda_graph_forward_prop_cache;
+  /** @brief Cache of CUDA graphs for cuDNN backprop functions */
+  cuda_graph_cache_map_t m_cuda_graph_backward_prop_cache;
 #endif // LBANN_GRU_LAYER_GPU_SUPPORTED
 
   template <typename T>

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -531,8 +531,11 @@ void fp_compute_impl(
   hash = hash_combine(hash, l.m_cudnn_reserve_space.data());
 
   // Update CUDA graph if cuDNN function arguments don't match
-  if (l.m_cuda_graph_forward_prop_hash != hash) {
-    l.m_cuda_graph_forward_prop_hash = hash;
+  cuda_graph_cache_map_t::const_iterator it = l.m_cuda_graph_forward_prop_cache.find(mini_batch_size);
+
+  if (it == l.m_cuda_graph_forward_prop_cache.end() ||
+      l.m_cuda_graph_forward_prop_cache[mini_batch_size].m_hash != hash) {
+    l.m_cuda_graph_forward_prop_cache[mini_batch_size].m_hash = hash;
     cuda::Graph::begin_capture(stream);
     CHECK_CUDNN(
       cudnnRNNForward(
@@ -557,11 +560,11 @@ void fp_compute_impl(
         l.m_cudnn_reserve_space.size(),
         l.m_cudnn_reserve_space.data()));
     auto graph = cuda::Graph::end_capture(stream);
-    l.m_cuda_graph_forward_prop.update(graph);
+    l.m_cuda_graph_forward_prop_cache[mini_batch_size].m_graph.update(graph);
   }
 
   // Launch CUDA graph with cuDNN kernels
-  l.m_cuda_graph_forward_prop.launch(stream);
+  l.m_cuda_graph_forward_prop_cache[mini_batch_size].m_graph.launch(stream);
 
 }
 
@@ -778,8 +781,11 @@ void bp_compute_impl(
   hash = hash_combine(hash, l.m_cudnn_reserve_space.data());
 
   // Update CUDA graph if cuDNN function arguments don't match
-  if (l.m_cuda_graph_backward_prop_hash != hash) {
-    l.m_cuda_graph_backward_prop_hash = hash;
+  cuda_graph_cache_map_t::const_iterator it = l.m_cuda_graph_backward_prop_cache.find(mini_batch_size);
+
+  if (it == l.m_cuda_graph_backward_prop_cache.end() ||
+      l.m_cuda_graph_backward_prop_cache[mini_batch_size].m_hash != hash) {
+    l.m_cuda_graph_backward_prop_cache[mini_batch_size].m_hash = hash;
     cuda::Graph::begin_capture(stream);
     CHECK_CUDNN(
       cudnnRNNBackwardData_v8(
@@ -824,11 +830,11 @@ void bp_compute_impl(
         l.m_cudnn_reserve_space.size(),
         l.m_cudnn_reserve_space.data()));
     auto graph = cuda::Graph::end_capture(stream);
-    l.m_cuda_graph_backward_prop.update(graph);
+    l.m_cuda_graph_backward_prop_cache[mini_batch_size].m_graph.update(graph);
   }
 
   // Launch CUDA graph with cuDNN kernels
-  l.m_cuda_graph_backward_prop.launch(stream);
+  l.m_cuda_graph_backward_prop_cache[mini_batch_size].m_graph.launch(stream);
 
   // Send gradients to optimizers
   unpack_cudnn_rnn_weights<TensorDataType>(


### PR DESCRIPTION
have unordered maps that contain a computed graph for each mini-batch
size.  Using the mini-batch as the key ensures that if a phase has new
buffers but the same mini-batch size, it will overwrite the existing
graph cache, avoiding memory leaks.